### PR TITLE
Api for admin districts

### DIFF
--- a/ECMasterDataAPI/ECMasterDataAPI/Controllers/AdminDistrictController.cs
+++ b/ECMasterDataAPI/ECMasterDataAPI/Controllers/AdminDistrictController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ECMasterDataAPI.Models.StoredProceduers;
+using ECMasterDataAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ECMasterDataAPI.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AdminDistrictController : ControllerBase
+    {
+        private readonly VotRegContext _context;
+
+        public AdminDistrictController(VotRegContext context)
+        {
+            _context = context;
+        }
+        // GET: api/admindistrict
+        [HttpGet]
+        public async Task<List<SpAdminDistricts>> Get()
+        {
+            return await _context.GetAdminDistrictsAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<List<SpAdminDistricts>> GetById(int id)
+        {
+            return await _context.GetAdminDistrictByIdAsync(id);
+        }
+
+
+    }
+}

--- a/ECMasterDataAPI/ECMasterDataAPI/Models/StoredProceduers/SpAdminDistricts.cs
+++ b/ECMasterDataAPI/ECMasterDataAPI/Models/StoredProceduers/SpAdminDistricts.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ECMasterDataAPI.Models.StoredProceduers
+{
+    public class SpAdminDistricts
+    {
+        public byte AdisId { get; set; }
+        public string DisCode { get; set; }
+        public byte? EdisId { get; set; }
+        public string DistrictNameEN { get; set; }
+        public string DistrictNameSI { get; set; }
+        public string DistrictNameTA { get; set; }
+        public string Des { get; set; }
+        public byte? ProvID { get; set; }
+        public byte? LocCodeID { get; set; }
+        public string LocCode { get; set; }
+        public short? AddBy { get; set; }
+        public DateTime? DateAdd { get; set; }
+        public short? UpdateBy { get; set; }
+        public DateTime? DateUpdate { get; set; }
+    }
+}

--- a/ECMasterDataAPI/ECMasterDataAPI/Models/VotRegContext.cs
+++ b/ECMasterDataAPI/ECMasterDataAPI/Models/VotRegContext.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using ECMasterDataAPI.Models.StoredProceduers;
+using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -924,6 +929,49 @@ namespace ECMasterDataAPI.Models
 
                 entity.Property(e => e.VerifyBy).HasDefaultValueSql("((0))");
             });
+
+            modelBuilder.Query<SpAdminDistricts>();
+        }
+
+        public async Task<List<SpAdminDistricts>> GetAdminDistrictsAsync()
+        {
+            List<SpAdminDistricts> lst = new List<SpAdminDistricts>();
+
+            string sqlQuery = "EXEC [dbo].[spADis]";
+
+            try
+            {
+                lst = await this.Query<SpAdminDistricts>().FromSql(sqlQuery).ToListAsync();
+            }
+            catch(Exception ex)
+            {
+                throw ex;
+            }
+
+            // Info.  
+            return lst;
+        }
+
+        public async Task<List<SpAdminDistricts>> GetAdminDistrictByIdAsync(int id)
+        {
+            List<SpAdminDistricts> lst = new List<SpAdminDistricts>();
+
+            SqlParameter param =  new SqlParameter("@id", id);
+
+            // Processing.  
+            string sqlQuery = "EXEC [dbo].[spADisById] " + "@id";
+
+            try
+            {
+                lst = await this.Query<SpAdminDistricts>().FromSql(sqlQuery, param).ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+
+            // Info.  
+            return lst;
         }
     }
 }

--- a/ECMasterDataAPI/ECMasterDataAPI/Properties/launchSettings.json
+++ b/ECMasterDataAPI/ECMasterDataAPI/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/pollingdistrict",
+      "launchUrl": "api/admindistrict",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
API was created for **spADis** and **spADisByID** stored procedures

Endpoints
- https://localhost:port/api/admindistrict
- https://localhost:port/api/admindistrict/1

API documentation can be found at
- https://localhost:port/swagger

1. Created a new model class under Models/StoredProcedure name SpAdminDistricts
2. Added the properties to the model class to match with the properties return from the SP
3. Added a method to the VotRegContext called GetAdminDistrictsAsync which executes the spADis.
4. Added a method to the VotRegContext called GetAdminDistrictByIdAsync which executes the spADisByID by passing the district id as a parameter.
5. Register stored procedures access object SpAdminDistricts in OnModelCreating of the VotRegContext
6. Created a controller named AdminDistrictsController and added two endpoints to return all the districts as well as a single district when the id is passed as a query paramater